### PR TITLE
Remove required owner for syntax checker (#94)

### DIFF
--- a/internal/check/valid_syntax.go
+++ b/internal/check/valid_syntax.go
@@ -44,10 +44,6 @@ func (ValidSyntax) Check(ctx context.Context, in Input) (Output, error) {
 			bldr.ReportIssue("Missing pattern", WithEntry(entry))
 		}
 
-		if len(entry.Owners) == 0 {
-			bldr.ReportIssue("Missing owner, at least one owner is required", WithEntry(entry))
-		}
-
 	ownersLoop:
 		for _, item := range entry.Owners {
 			switch {

--- a/internal/check/valid_syntax_test.go
+++ b/internal/check/valid_syntax_test.go
@@ -17,14 +17,6 @@ func TestValidSyntaxChecker(t *testing.T) {
 		codeowners string
 		issue      check.Issue
 	}{
-		"No owners": {
-			codeowners: `*`,
-			issue: check.Issue{
-				Severity: check.Error,
-				LineNo:   ptr.Uint64Ptr(1),
-				Message:  "Missing owner, at least one owner is required",
-			},
-		},
 		"Bad username": {
 			codeowners: `pkg/github.com/** @-`,
 			issue: check.Issue{
@@ -106,11 +98,6 @@ func TestValidSyntaxZeroValueEntry(t *testing.T) {
 			Severity: check.Error,
 			Message:  "Missing pattern",
 		},
-		{
-			LineNo:   ptr.Uint64Ptr(0),
-			Severity: check.Error,
-			Message:  "Missing owner, at least one owner is required",
-		},
 	}
 
 	// when
@@ -120,6 +107,6 @@ func TestValidSyntaxZeroValueEntry(t *testing.T) {
 	// then
 	require.NoError(t, err)
 
-	require.Len(t, out.Issues, 2)
+	require.Len(t, out.Issues, 1)
 	assert.EqualValues(t, expIssues, out.Issues)
 }


### PR DESCRIPTION
<!--   Thank you for your contribution -->

**Description**

Changes proposed in this pull request:

- This PR removes the missing owner syntax check, as this is [a valid use case](https://github.com/github/docs/blob/209c340039acc4c2f73c2eb1fcd607af00911118/content/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners.md#L103) to explicitly specify that a path has no owner. 

**Related issue(s)**

Resolves #1 

