### PR TITLE
Enforce only one CODEOWNERS file

### DIFF
--- a/pkg/codeowners/owners.go
+++ b/pkg/codeowners/owners.go
@@ -38,6 +38,8 @@ func NewFromPath(path string) ([]Entry, error) {
 // openCodeownersFile finds a CODEOWNERS file and returns content.
 // see: https://help.github.com/articles/about-code-owners/#codeowners-file-location
 func openCodeownersFile(dir string) (io.Reader, error) {
+	var fileReader io.Reader = nil
+
 	for _, p := range []string{".", "docs", ".github"} {
 		pth := path.Join(dir, p)
 		exists, err := afero.DirExists(fs, pth)
@@ -58,8 +60,13 @@ func openCodeownersFile(dir string) (io.Reader, error) {
 		default:
 			return nil, err
 		}
-
-		return fs.Open(f)
+		if fileReader != nil {
+			return nil, fmt.Errorf("Multiple CODEOWNERS files found in root, docs/, or .github/ directory of the repository %s", dir)
+		}
+		fileReader, err = fs.Open(f)
+	}
+	if fileReader != nil {
+		return fileReader, nil
 	}
 
 	return nil, fmt.Errorf("No CODEOWNERS found in the root, docs/, or .github/ directory of the repository %s", dir)

--- a/pkg/codeowners/owners_test.go
+++ b/pkg/codeowners/owners_test.go
@@ -113,3 +113,25 @@ func TestFindCodeownersFileFailure(t *testing.T) {
 	assert.EqualError(t, err, expErrMsg)
 	assert.Nil(t, entries)
 }
+
+func TestMultipleCodeownersFileFailure(t *testing.T) {
+	// given
+	tFS := afero.NewMemMapFs()
+	revert := codeowners.SetFS(tFS)
+	defer revert()
+
+	givenRepoPath := "/workspace/go/repo-with-multiple-codeowners/"
+	expErrMsg := fmt.Sprintf("Multiple CODEOWNERS files found in root, docs/, or .github/ directory of the repository %s", givenRepoPath)
+
+	_, err := tFS.Create(path.Join(givenRepoPath, "CODEOWNERS"))
+	require.NoError(t, err)
+	_, err = tFS.Create(path.Join(givenRepoPath, "docs/", "CODEOWNERS"))
+	require.NoError(t, err)
+
+	// when
+	entries, err := codeowners.NewFromPath(givenRepoPath)
+
+	// then
+	assert.EqualError(t, err, expErrMsg)
+	assert.Nil(t, entries)
+}


### PR DESCRIPTION
<!--   Thank you for your contribution -->

**Description**

Adds a check for multiple codeowner files

**Related issue(s)**

https://github.com/mszostok/codeowners-validator/issues/97

